### PR TITLE
Update sequence flow to use new link tools

### DIFF
--- a/src/components/nodes/sequenceFlow/sequenceFlow.vue
+++ b/src/components/nodes/sequenceFlow/sequenceFlow.vue
@@ -8,7 +8,7 @@ import crownConfig from '@/mixins/crownConfig';
 import linkConfig from '@/mixins/linkConfig';
 import get from 'lodash/get';
 import { id as laneId } from '../poolLane';
-import { expressionPosition, arrowheadShape } from './sequenceFlowConfig';
+import { expressionPosition } from './sequenceFlowConfig';
 
 export default {
   props: ['graph', 'node', 'id', 'moddle', 'nodeRegistry'],
@@ -147,19 +147,8 @@ export default {
     },
   },
   mounted() {
-    this.shape = new joint.dia.Link({
-      router: {
-        name: 'orthogonal',
-      },
-      attrs: {
-        '.connection': { stroke: 'black', strokeWidth: 2 },
-        '.marker-arrowhead[end="source"]': { display: 'none' },
-        '.marker-arrowhead[end="target"]': { d: arrowheadShape },
-        '.marker-target': { d: arrowheadShape },
-        '.tool-remove': { display: 'none' },
-        '.marker-vertex': { r: 5 },
-      },
-    });
+    this.shape = new joint.shapes.standard.Link();
+
     this.createLabel();
   },
 };

--- a/src/components/nodes/sequenceFlow/sequenceFlowConfig.js
+++ b/src/components/nodes/sequenceFlow/sequenceFlowConfig.js
@@ -1,2 +1,1 @@
 export const expressionPosition = { offset: -25 };
-export const arrowheadShape = 'M 10 0 L 0 5 L 10 10 z';

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -34,6 +34,7 @@ export default {
       /* allowSetNodePosition is used to prevent setting a node position outside of a pool */
       allowSetNodePosition: true,
       savePositionOnPointerupEventSet: false,
+      shape: null,
     };
   },
   watch: {

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -5,6 +5,7 @@ import debounce from 'lodash/debounce';
 import { validNodeColor, invalidNodeColor, defaultNodeColor } from '@/components/nodeColors';
 
 export default {
+  props: ['highlighted'],
   data() {
     return {
       sourceShape: null,
@@ -23,6 +24,13 @@ export default {
         this.shape.stopListening(this.paper, 'blank:pointerdown link:pointerdown element:pointerdown', this.removeLink);
       } else {
         this.shape.listenToOnce(this.paper, 'blank:pointerdown link:pointerdown element:pointerdown', this.removeLink);
+      }
+    },
+    highlighted(highlighted) {
+      if (highlighted) {
+        this.shapeView.showTools();
+      } else {
+        this.shapeView.hideTools();
       }
     },
   },
@@ -135,6 +143,17 @@ export default {
         this.setBodyColor(defaultNodeColor);
       }
     },
+    setupLinkTools() {
+      const verticesTool = new joint.linkTools.Vertices();
+      const segmentsTool = new joint.linkTools.Segments();
+
+      const toolsView = new joint.dia.ToolsView({
+        tools: [verticesTool, segmentsTool],
+      });
+
+      this.shapeView.addTools(toolsView);
+      this.shapeView.hideTools();
+    },
   },
   created() {
     this.updateWaypoints = debounce(this.updateWaypoints, 100);
@@ -155,6 +174,8 @@ export default {
 
     this.shape.addTo(this.graph);
     this.shape.component = this;
+
+    this.setupLinkTools();
 
     const targetRef = this.node.definition.get('targetRef');
 


### PR DESCRIPTION
Fixes #330. This PR updates sequence flows to use JointJS LinkTools:
 * Link tools (adding vertices, removing vertices, moving segments) only appear after the node is highlighted.
 * As a consequence of the above, you can only add new vertices after highlighting the node.
 * Automatically removes redundant vertices.
 * Double click to remove added vertices.
 * Can now drag line segments.
 * No outline on hover; sequence flow looks more like the original.
 * Better icons when hovering (for move, add, select).

![spark_new_flows](https://user-images.githubusercontent.com/7561061/55982076-1594be80-5c66-11e9-8c0a-b1801a557723.gif)
