### PR TITLE
Highlight flows

### DIFF
--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -28,8 +28,17 @@ export default {
     },
     highlighted(highlighted) {
       if (highlighted) {
+        this.shape.attr({
+          line: { stroke: 'orange' },
+          '.joint-highlight-stroke': {'display': 'none'},
+        });
+
         this.shapeView.showTools();
       } else {
+        this.shape.attr({
+          line: { stroke: 'black' },
+        });
+
         this.shapeView.hideTools();
       }
     },


### PR DESCRIPTION

![hightlight-flow](https://user-images.githubusercontent.com/26545455/56301074-14034480-6105-11e9-97b3-c0e7a89562b9.gif)

- Highlight bounding box is removed
- Flows will be highlighted instead

Fixes #343 
