### PR TITLE
Fix drag and drop across browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5103,7 +5103,8 @@
     "core-js": {
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -7359,8 +7360,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7381,14 +7381,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7403,20 +7401,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7533,8 +7528,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7546,7 +7540,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7561,7 +7554,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7569,14 +7561,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7595,7 +7585,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7676,8 +7665,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7689,7 +7677,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7775,8 +7762,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7812,7 +7798,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7832,7 +7817,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7876,14 +7860,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -8875,8 +8857,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
@@ -8933,7 +8914,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -18091,8 +18071,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
@@ -19637,8 +19616,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",
@@ -20657,14 +20635,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/vue-deepset/-/vue-deepset-0.6.3.tgz",
       "integrity": "sha512-Qyj40hwEAWb8LqeiayfEd9mOQWO9npCNrgQJlFwzx5sxE4+UKrc3F+dnqpgPD4T8HrBayVT3L0tyoKB1FUwtgg=="
-    },
-    "vue-drag-drop": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/vue-drag-drop/-/vue-drag-drop-1.1.4.tgz",
-      "integrity": "sha512-zrpvKcD5LPVbht7cJ7ZBY0poS8GDLibRck18Zx0polkoSSpTPNMAv/m/b98xtZ3I1jdWGyiPybfPgKFFkygjhQ==",
-      "requires": {
-        "core-js": "^2.5.3"
-      }
     },
     "vue-eslint-parser": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "npm": "^6.4.1",
     "vue": "^2.5.17",
     "vue-deepset": "^0.6.3",
-    "vue-drag-drop": "^1.1.4",
     "vue-upload-component": "^2.8.14",
     "vuejs-datepicker": "^1.5.4",
     "vuex": "^3.0.1"

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -30,9 +30,7 @@
 
         <button class="validate-button" @click="validateBpmnDiagram">Validate Diagram</button>
 
-        <!-- <drop @drop="handleDrop" @dragover="validateDropTarget"> -->
         <div ref="paper" data-test="paper"/>
-        <!-- </drop> -->
       </div>
 
       <InspectorPanel
@@ -89,10 +87,6 @@ import { Linter } from 'bpmnlint';
 import linterConfig from '../../.bpmnlintrc';
 import NodeIdGenerator from '../NodeIdGenerator';
 import Process from './inspectors/process';
-
-// Our renderer for our inspector
-import { Drop } from 'vue-drag-drop';
-
 import { id as poolId } from './nodes/pool';
 import { id as laneId } from './nodes/poolLane';
 import { id as sequenceFlowId } from './nodes/sequenceFlow';
@@ -103,7 +97,6 @@ const version = '1.0';
 
 export default {
   components: {
-    Drop,
     controls,
     InspectorPanel,
   },

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -1,10 +1,18 @@
 <template>
   <div class="modeler">
     <div class="modeler-container">
-      <controls :controls="controls" :style="{ height: parentHeight }"/>
+      <controls
+        :controls="controls"
+        :style="{ height: parentHeight }"
+        :invalidDrop="validateDropTarget"
+        :allowDrop="allowDrop"
+        @drag="validateDropTarget"
+        @handleDrop="handleDrop"
+      />
 
       <div
         class="paper-container"
+        ref="paper-container"
         :class="cursor"
         :style="{ width: parentWidth, height: parentHeight }"
       >
@@ -22,9 +30,9 @@
 
         <button class="validate-button" @click="validateBpmnDiagram">Validate Diagram</button>
 
-        <drop @drop="handleDrop" @dragover="validateDropTarget">
-          <div ref="paper" data-test="paper"/>
-        </drop>
+        <!-- <drop @drop="handleDrop" @dragover="validateDropTarget"> -->
+        <div ref="paper" data-test="paper"/>
+        <!-- </drop> -->
       </div>
 
       <InspectorPanel
@@ -471,12 +479,12 @@ export default {
     toXML(cb) {
       this.moddle.toXML(this.definitions, { format: true }, cb);
     },
-    handleDrop(transferData, event) {
+    handleDrop({ clientX, clientY, type }) {
+      this.validateDropTarget({ clientX, clientY, type });
+
       if (!this.allowDrop) {
         return;
       }
-
-      const type = transferData.type;
 
       // Add to our processNode
       const definition = this.nodeRegistry[type].definition(this.moddle);
@@ -486,8 +494,8 @@ export default {
 
       // Handle transform
       const paperOrigin = this.paper.localToPagePoint(0, 0);
-      diagram.bounds.x = event.clientX - paperOrigin.x;
-      diagram.bounds.y = event.clientY - paperOrigin.y;
+      diagram.bounds.x = clientX - paperOrigin.x;
+      diagram.bounds.y = clientY - paperOrigin.y;
 
       // Our BPMN models are updated, now add to our nodes
       // @todo come up with random id
@@ -557,9 +565,21 @@ export default {
 
       this.paper.setDimensions(clientWidth, clientHeight);
     },
-    validateDropTarget(transferData, { clientX, clientY }) {
+    isPointOverPool(mouseX, mouseY) {
+      const { x, y, width, height } = this.$refs['paper-container'].getBoundingClientRect();
+      const rect = new joint.g.rect(x, y, width, height);
+      const point = new joint.g.point(mouseX, mouseY);
+
+      return rect.containsPoint(point);
+    },
+    validateDropTarget({ clientX, clientY, type }) {
+      if (!this.isPointOverPool(clientX, clientY)) {
+        this.allowDrop = false;
+        return;
+      }
+
       /* You can drop a pool anywhere (a pool will not be embedded into another pool) */
-      if (transferData.type === poolId) {
+      if (type === poolId) {
         this.allowDrop = true;
         return;
       }

--- a/src/components/controls.vue
+++ b/src/components/controls.vue
@@ -11,42 +11,137 @@
     <div class="list">
       <div v-for="(items, category) in controls" :key="category">
         <h2>{{ $t(category) }}</h2>
-        <drag
+        <div
           v-for="(control, index) in items"
           :key="index"
           :transfer-data="{type: control.type}"
           v-if="control.label.toLowerCase().includes(filterQuery.toLowerCase())"
           :data-test="control.type"
+          @dragstart="$event.preventDefault()"
+          @mousedown="startDrag($event, control.type)"
         >
           <div class="tool">
             <div class="img-container">
               <img :src="control.icon">
             </div>
-            <div>{{ $t(control.label) }}</div>
+            {{ $t(control.label) }}
           </div>
-        </drag>
+        </div>
       </div>
     </div>
   </div>
 </template>
 
 <script>
-import { Drag } from 'vue-drag-drop';
+// import { Drag } from 'vue-drag-drop';
 
 export default {
-  props: ['controls'],
-  components: {
-    Drag,
+  props: ['controls', 'allowDrop'],
+  // components: {
+  //   Drag,
+  // },
+  watch: {
+    allowDrop(allowDrop) {
+      if (this.draggingElement) {
+        this.draggingElement.classList.toggle('no-drop', !allowDrop);
+      }
+    },
   },
   data() {
     return {
       filterQuery: '',
+      draggingElement: null,
+      draggingControlType: null,
+      xOffset: null,
+      yOffset: null,
     };
+  },
+  methods: {
+    startDrag(event, controlType) {
+      const sourceElement = event.target;
+      const duplicateElement = sourceElement.cloneNode(true);
+      duplicateElement.classList.add('is-dragging');
+      duplicateElement.classList.toggle('no-drop', !this.allowDrop);
+      duplicateElement.style.width = `${sourceElement.clientWidth}px`;
+      duplicateElement.style.height = `${sourceElement.clientHeight}px`;
+
+      this.$root.$el.appendChild(duplicateElement);
+      this.xOffset = event.clientX - sourceElement.getBoundingClientRect().left;
+      this.yOffset = event.clientY - sourceElement.getBoundingClientRect().top;
+      this.draggingElement = duplicateElement;
+      this.draggingControlType = controlType;
+
+      document.addEventListener('mousemove', this.setDraggingPosition);
+      document.addEventListener('mouseup', this.dropElement);
+      document.addEventListener('keyup', this.stopDrag);
+
+      this.setDraggingPosition(event);
+    },
+    stopDrag(event) {
+      if (event && event.key !== 'Escape') {
+        return;
+      }
+
+      document.removeEventListener('mousemove', this.setDraggingPosition);
+      document.removeEventListener('mouseup', this.dropElement);
+      document.removeEventListener('keyup', this.stopDrag);
+
+      this.$root.$el.removeChild(this.draggingElement);
+      this.draggingElement = null;
+      this.draggingControlType = null;
+    },
+    dropElement({ clientX, clientY }) {
+      this.$emit('handleDrop', { clientX, clientY, type: this.draggingControlType });
+      this.stopDrag();
+    },
+    setDraggingPosition({ pageX, pageY, clientX, clientY }) {
+      this.draggingElement.style.left = pageX - this.xOffset + 'px';
+      this.draggingElement.style.top = pageY - this.yOffset + 'px';
+      this.$emit('drag', { clientX, clientY, type: this.draggingControlType });
+    },
   },
 };
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
+.tool {
+  display: flex;
+  align-items: center;
+  font-size: 0.75em;
+  padding: 4px;
+  font-weight: bold;
+  color: #333;
+  cursor: grab;
+  user-select: none;
+
+  &.is-dragging {
+    background: #3397e1;
+    color: white;
+    position: absolute;
+    z-index: 10;
+    box-shadow: 5px 5px 8px 0px #0000004a;
+    cursor: grabbing;
+    text-align: left;
+
+    &.no-drop {
+      opacity: 0.8;
+      cursor: no-drop;
+    }
+  }
+
+  &:hover {
+    background-color: #3397e1;
+    color: white;
+  }
+
+  .img-container {
+    pointer-events: none;
+    margin-right: 8px;
+    width: 32px;
+    text-align: center;
+  }
+}
+
 .controls {
   background-color: #eee;
   border-right: 1px solid #aaa;
@@ -58,6 +153,7 @@ export default {
   .list {
     overflow: auto;
     height: 100%;
+    position: relative;
 
     h2 {
       background-color: #aaa;
@@ -69,27 +165,6 @@ export default {
       font-weight: bold;
       padding-bottom: 8px;
       padding-top: 8px;
-    }
-
-    .tool {
-      display: flex;
-      align-items: center;
-      font-size: 0.75em;
-      padding: 4px;
-      font-weight: bold;
-      color: #333;
-      cursor: pointer;
-
-      &:hover {
-        background-color: #3397e1;
-        color: white;
-      }
-
-      .img-container {
-        margin-right: 8px;
-        width: 32px;
-        text-align: center;
-      }
     }
   }
 }

--- a/src/components/controls.vue
+++ b/src/components/controls.vue
@@ -33,13 +33,8 @@
 </template>
 
 <script>
-// import { Drag } from 'vue-drag-drop';
-
 export default {
   props: ['controls', 'allowDrop'],
-  // components: {
-  //   Drag,
-  // },
   watch: {
     allowDrop(allowDrop) {
       if (this.draggingElement) {

--- a/src/components/controls.vue
+++ b/src/components/controls.vue
@@ -13,9 +13,8 @@
         <h2>{{ $t(category) }}</h2>
         <div
           v-for="(control, index) in items"
-          :key="index"
-          :transfer-data="{type: control.type}"
           v-if="control.label.toLowerCase().includes(filterQuery.toLowerCase())"
+          :key="index"
           :data-test="control.type"
           @dragstart="$event.preventDefault()"
           @mousedown="startDrag($event, control.type)"

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -42,11 +42,14 @@ export function getLinksConnectedToElement($element) {
 }
 
 export function dragFromSourceToDest(source, position) {
-  const dataTransfer = new DataTransfer();
-  const paper = '.paper-container';
-  cy.get(`[data-test=${ source }]`).trigger('dragstart', { dataTransfer });
-  cy.get(paper).trigger('dragenter', { force: true });
-  cy.get(paper).trigger('drop', { x: position.x, y: position.y });
+  cy.get('.paper-container').then($paperContainer => {
+    const { x, y } = $paperContainer[0].getBoundingClientRect();
+    const mouseEvent = { clientX: position.x + x, clientY: position.y + y };
+
+    cy.get(`[data-test=${ source }]`).trigger('mousedown');
+    cy.document().trigger('mousemove', mouseEvent);
+    cy.document().trigger('mouseup', mouseEvent);
+  });
 }
 
 export function getCrownButtonForElement($element, crownButton) {


### PR DESCRIPTION
Fixes #321.

This PR removes `vue-drag-drop` and replaced it with a cross-browser implementation that doesn't rely on the native  html5 drag and drop API.

On macOS Chrome 74:
![spark-chrome-74](https://user-images.githubusercontent.com/7561061/56684267-64e2e200-669d-11e9-93fc-0d38bc07bb8d.gif)


On Windows 10 Edge 18 (lag is due to running inside BrowserStack):
![spark-win-10](https://user-images.githubusercontent.com/7561061/56684165-32d18000-669d-11e9-9a3e-fb9fc866102d.gif)

How it used to look in Edge:
![spark-win-10-old](https://user-images.githubusercontent.com/7561061/56684563-05d19d00-669e-11e9-9fb8-7023e9bdba87.gif)
