### PR TITLE
Fix message flow bug when connected with pools

### DIFF
--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -8,6 +8,7 @@ import crownConfig from '@/mixins/crownConfig';
 import resizeConfig from '@/mixins/resizeConfig';
 import Lane from '../poolLane';
 import { id as poolId } from './index';
+import { id as messageFlowId } from '@/components/nodes/messageFlow/index';
 import { poolPadding, labelWidth } from './poolSizes';
 import { id as laneId } from '../poolLane';
 import laneAboveIcon from '@/assets/lane-above.svg';
@@ -174,6 +175,10 @@ export default {
       }
     },
     expandToFitElement(element) {
+      if (element.component.node.type === messageFlowId) {
+        return;
+      }
+
       const { x: poolX, y: poolY, width, height } = this.shape.getBBox();
 
       if (element.component.node.type === laneId) {

--- a/src/mixins/resizeConfig.js
+++ b/src/mixins/resizeConfig.js
@@ -43,14 +43,8 @@ export default {
   },
   methods: {
     calculateElementLimits() {
-      const isMessageFlowConnected = this.elementBounds.length > 0;
-
-      if (isMessageFlowConnected) {
-        return;
-      }
-
       this.elementBounds = this.poolComponent.shape.getEmbeddedCells()
-        .filter(element => element.component && element.component.node.type !== laneId)
+        .filter(element => element.component && element.component.node.type !== laneId && element.component.node.type !== 'processmaker-modeler-message-flow')
         .map(element => element.getBBox());
 
       this.elementTopY = Math.min(...this.elementBounds.map(({ y }) => y - poolPadding));

--- a/src/mixins/resizeConfig.js
+++ b/src/mixins/resizeConfig.js
@@ -43,6 +43,12 @@ export default {
   },
   methods: {
     calculateElementLimits() {
+      const isMessageFlowConnected = this.elementBounds.length > 0;
+
+      if (isMessageFlowConnected) {
+        return;
+      }
+
       this.elementBounds = this.poolComponent.shape.getEmbeddedCells()
         .filter(element => element.component && element.component.node.type !== laneId)
         .map(element => element.getBBox());

--- a/tests/e2e/specs/MessageFlows.spec.js
+++ b/tests/e2e/specs/MessageFlows.spec.js
@@ -3,6 +3,7 @@ import {
   getElementAtPosition,
   connectNodesWithFlow,
   getLinksConnectedToElement,
+  moveElement,
 } from '../support/utils';
 
 import { nodeTypes } from '../support/constants';
@@ -20,6 +21,9 @@ describe('Message Flows', () => {
     dragFromSourceToDest(nodeTypes.pool, pool2Position);
 
     connectNodesWithFlow('message-flow-button', pool1Position, pool2Position);
+
+    moveElement(pool1Position, 300, 300);
+    moveElement(pool1Position, 250, 250);
 
     const numberOfMessageFlowsAdded = 1;
     getElementAtPosition(pool2Position)

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -101,3 +101,10 @@ export function isElementCovered($element) {
         });
     });
 }
+
+export function moveElement(elementPosition, x, y) {
+  getElementAtPosition(elementPosition)
+    .trigger('mousedown', { which: 1 })
+    .trigger('mousemove', { clientX: x, clientY: y })
+    .trigger('mouseup', {force: true});
+}


### PR DESCRIPTION
**To Test**
- Drag two pools to the canvas
- Connect pools with a message flow
- Drag both pools and message flow around the canvas

**Expected Behaviour**
- Interaction with elements should behave as normal

Modify `Can connect two pools with a message flow` test to reproduce the bug.

Fixes #347 