### PR TITLE
Fix import rendering

### DIFF
--- a/src/components/nodes/task/index.js
+++ b/src/components/nodes/task/index.js
@@ -5,7 +5,7 @@ export const taskHeight = 76;
 export default {
   id: 'processmaker-modeler-task',
   component,
-  bpmnType: ['bpmn:Task', 'bpmn:UserTask', 'bpmn:ManualTask'],
+  bpmnType: ['bpmn:Task', 'bpmn:UserTask', 'bpmn:ManualTask', 'bpmn:GlobalTask', 'bpmn:SubProcess'],
   control: true,
   category: 'BPMN',
   icon: require('@/assets/toolpanel/task.svg'),

--- a/src/components/nodes/task/index.js
+++ b/src/components/nodes/task/index.js
@@ -5,7 +5,7 @@ export const taskHeight = 76;
 export default {
   id: 'processmaker-modeler-task',
   component,
-  bpmnType: ['bpmn:Task', 'bpmn:UserTask'],
+  bpmnType: ['bpmn:Task', 'bpmn:UserTask', 'bpmn:ManualTask'],
   control: true,
   category: 'BPMN',
   icon: require('@/assets/toolpanel/task.svg'),


### PR DESCRIPTION
Add manual, subprocess and global task as unsupported elements.

Unsupported task elements will default to normal tasks.

Fixes #353 