### PR TITLE
Intermediate Message Catch Event: Change references of dataName to variableName

### DIFF
--- a/src/components/nodes/intermediateMessageCatchEvent/index.js
+++ b/src/components/nodes/intermediateMessageCatchEvent/index.js
@@ -18,7 +18,7 @@ export default {
       eventDefinitions: [
         moddle.create('bpmn:MessageEventDefinition', {
           id: '',
-          dataName: '',
+          variableName: '',
         }),
       ],
     });
@@ -37,7 +37,7 @@ export default {
     return Object.entries(node.definition).reduce((data, [key, value]) => {
       if (key === 'eventDefinitions') {
         data.eventDefinitionId = value[0].get('id');
-        data.dataName = value[0].get('dataName');
+        data.variableName = value[0].get('variableName');
       } else {
         data[key] = value;
       }
@@ -46,7 +46,7 @@ export default {
     }, {});
   },
   inspectorHandler(value, node, setNodeProp, moddle) {
-    for (const key in omit(value, ['$type', 'eventDefinitionId', 'dataName'])) {
+    for (const key in omit(value, ['$type', 'eventDefinitionId', 'variableName'])) {
       if (node.definition[key] === value[key]) {
         continue;
       }
@@ -55,13 +55,13 @@ export default {
     }
 
     if (
-      node.definition.eventDefinitions[0].get('id') !== value.dataName ||
-      node.definition.eventDefinitions[0].get('dataName') !== value.eventDefinitionId
+      node.definition.eventDefinitions[0].get('id') !== value.variableName ||
+      node.definition.eventDefinitions[0].get('variableName') !== value.eventDefinitionId
     ) {
       setNodeProp(node, 'eventDefinitions', [
         moddle.create('bpmn:MessageEventDefinition', {
           id: value['eventDefinitionId'],
-          dataName: value['dataName'],
+          variableName: value['variableName'],
         }),
       ]);
     }
@@ -114,9 +114,9 @@ export default {
             {
               component: 'FormInput',
               config: {
-                label: 'Data Name',
-                helper: 'The Name of the data name',
-                name: 'dataName',
+                label: 'Variable Name',
+                helper: 'The Name of the variable name',
+                name: 'variableName',
               },
             },
             {

--- a/tests/e2e/specs/IntermediateMessageCatchEvent.spec.js
+++ b/tests/e2e/specs/IntermediateMessageCatchEvent.spec.js
@@ -35,8 +35,9 @@ describe('Intermediate Message Catch Event', () => {
     const whiteList = 'example.com';
     typeIntoTextInput('[name=whitelist]', whiteList);
 
-    const validXML = `<bpmn:intermediateCatchEvent id="node_2" name="${name}" pm:allowedUsers="1,10" pm:allowedGroups="20,30" pm:whitelist="${whiteList}">
-      <bpmn:messageEventDefinition id="${eventId}" pm:variableName="${variableName}" />
+    const validXML =
+    `<bpmn:intermediateCatchEvent id="node_2" name="${name}" pm:allowedUsers="1,10" pm:allowedGroups="20,30" pm:whitelist="${whiteList}">
+      <bpmn:messageEventDefinition id="${eventId}" variableName="${variableName}" />
     </bpmn:intermediateCatchEvent>`;
 
     cy.get('[data-test=downloadXMLBtn]').click();

--- a/tests/e2e/specs/IntermediateMessageCatchEvent.spec.js
+++ b/tests/e2e/specs/IntermediateMessageCatchEvent.spec.js
@@ -26,8 +26,8 @@ describe('Intermediate Message Catch Event', () => {
     const eventId = '1234';
     typeIntoTextInput('[name=eventDefinitionId]', eventId);
 
-    const dataName = 'test variablename';
-    typeIntoTextInput('[name=variableName]', dataName);
+    const variableName = 'test variablename';
+    typeIntoTextInput('[name=variableName]', variableName);
 
     cy.get('[name=allowedUsers]').select('1,10');
     cy.get('[name=allowedGroups]').select('20,30');
@@ -36,7 +36,7 @@ describe('Intermediate Message Catch Event', () => {
     typeIntoTextInput('[name=whitelist]', whiteList);
 
     const validXML = `<bpmn:intermediateCatchEvent id="node_2" name="${name}" pm:allowedUsers="1,10" pm:allowedGroups="20,30" pm:whitelist="${whiteList}">
-      <bpmn:messageEventDefinition id="${eventId}" pm:dataName="${dataName}" />
+      <bpmn:messageEventDefinition id="${eventId}" pm:variableName="${variableName}" />
     </bpmn:intermediateCatchEvent>`;
 
     cy.get('[data-test=downloadXMLBtn]').click();

--- a/tests/e2e/specs/IntermediateMessageCatchEvent.spec.js
+++ b/tests/e2e/specs/IntermediateMessageCatchEvent.spec.js
@@ -26,8 +26,8 @@ describe('Intermediate Message Catch Event', () => {
     const eventId = '1234';
     typeIntoTextInput('[name=eventDefinitionId]', eventId);
 
-    const dataName = 'test dataname';
-    typeIntoTextInput('[name=dataName]', dataName);
+    const dataName = 'test variablename';
+    typeIntoTextInput('[name=variableName]', dataName);
 
     cy.get('[name=allowedUsers]').select('1,10');
     cy.get('[name=allowedGroups]').select('20,30');


### PR DESCRIPTION
Fixes #356 

```
<bpmn:intermediateCatchEvent id="node_2" name="Intermediate Message Catch Event" pm:allowedUsers="1,10" pm:allowedGroups="20,30" pm:whitelist="http://localhost:8080/">
      <bpmn:messageEventDefinition id="12" variableName="foo" />
    </bpmn:intermediateCatchEvent>
```

[intermediate-message-catch-event.xml.txt](https://github.com/ProcessMaker/spark-modeler/files/3133013/intermediate-message-catch-event.xml.txt)

<img width="214" alt="Screen Shot 2019-04-30 at 4 22 17 PM" src="https://user-images.githubusercontent.com/26545455/56990845-28fbc100-6b64-11e9-83aa-ff9ff7e87319.png">


