### PR TITLE
Fix duration expression to handle minutes

### DIFF
--- a/src/components/inspectors/DurationExpression.vue
+++ b/src/components/inspectors/DurationExpression.vue
@@ -6,7 +6,6 @@
       <input
         type="number"
         min="1"
-        :max="periodicity.max"
         class="form-control control repeat"
         :data-test="repeatInput"
         v-model="repeat"
@@ -32,10 +31,10 @@ export default {
   props: ['value', 'repeatInput'],
   data() {
     const periods = [
-      { name: periodNames.minute, value: 'M', max: 60, isTime: true },
-      { name: periodNames.hour, value: 'H', max: 24, isTime: true },
-      { name: periodNames.day, value: 'D', max: 365 },
-      { name: periodNames.month, value: 'M', max: 12 },
+      { name: periodNames.minute, value: 'M', isTime: true },
+      { name: periodNames.hour, value: 'H', isTime: true },
+      { name: periodNames.day, value: 'D' },
+      { name: periodNames.month, value: 'M' },
     ];
 
     return {
@@ -48,7 +47,7 @@ export default {
     value: {
       handler(value) {
         this.periodicity = this.getPeriodFromDelayString(value);
-        this.repeat = parseInt(value[value.length - 2]);
+        this.repeat = this.getRepeatNumberFromDelayString(value);
       },
       immediate: true,
     },
@@ -82,6 +81,10 @@ export default {
     },
     isTimePeriod(delayString) {
       return delayString[1] === 'T';
+    },
+    getRepeatNumberFromDelayString(delayString) {
+      const match = delayString.match(/\d+/);
+      return match && match[0];
     },
   },
 };

--- a/src/components/inspectors/DurationExpression.vue
+++ b/src/components/inspectors/DurationExpression.vue
@@ -21,14 +21,21 @@
 <script>
 import last from 'lodash/last';
 
+const periodNames = {
+  minute: 'minute',
+  hour: 'hour',
+  day: 'day',
+  month: 'month',
+};
+
 export default {
   props: ['value', 'repeatInput'],
   data() {
     const periods = [
-      { name: 'minute', value: 'M', max: 60, isTime: true },
-      { name: 'hour', value: 'H', max: 24, isTime: true },
-      { name: 'day', value: 'D', max: 365 },
-      { name: 'month', value: 'M', max: 12 },
+      { name: periodNames.minute, value: 'M', max: 60, isTime: true },
+      { name: periodNames.hour, value: 'H', max: 24, isTime: true },
+      { name: periodNames.day, value: 'D', max: 365 },
+      { name: periodNames.month, value: 'M', max: 12 },
     ];
 
     return {
@@ -64,7 +71,10 @@ export default {
       const periodicity = last(delayString);
 
       if (periodicity === 'M') {
-        const periodName = isTimePeriod ? 'minute' : 'month';
+        const periodName = isTimePeriod
+          ? periodNames.minute
+          : periodNames.month;
+
         return this.periods.find(({ name }) => name === periodName);
       }
 


### PR DESCRIPTION
Fixes #392, fixes #377.

**How to test:**
1. Import a intermediate timer event that has a delay property of `P1M`, and ensure it renders with 1 month selected.
2. Import a intermediate timer event that has a delay property of `PT1M`, and ensure it renders with 1 minute selected.
3. Toggle between the different delay properties and ensure they properly update the preview.
4. Ensure you can enter a number greater than 9 for the delay value.