### PR TITLE
Fix looping on sequence flows

### DIFF
--- a/src/components/nodes/sequenceFlow/sequenceFlow.vue
+++ b/src/components/nodes/sequenceFlow/sequenceFlow.vue
@@ -61,6 +61,7 @@ export default {
   methods: {
     updateRouter() {
       this.shape.router('manhattan',{
+        maximumLoops: 1,
         excludeEnds: ['source'],
         excludeTypes: ['standard.EmbeddedImage'],
         padding: 20,


### PR DESCRIPTION
By default the `manhattan` router has a default maximum number of iterations of the pathfinding loop which caused the redundant loops on the links. Demonstrated in the old behaviour video. Setting the maximum loops to 1, will prevent this.

![image](https://user-images.githubusercontent.com/26545455/58493283-94738700-8140-11e9-8674-11a9fb5eb8fa.png)


This is not a fix to save vertices to bpm xml. The looping behaviour will still happen if vertices are saved or not.

**Old Behaviour**
https://drive.google.com/open?id=1VO_vpqMm9iG7btHK9UO6HyUvgO9jblXa

**Current Implementation**
https://drive.google.com/open?id=1hjToK5ixmrXYvA0-Oy6OOmjF-0MggVIg

Fixes #382 