### PR TITLE
Fix translations by passing reference to $t

### DIFF
--- a/src/ModelerApp.vue
+++ b/src/ModelerApp.vue
@@ -139,7 +139,7 @@ export default {
   },
   mounted() {
     /* Add a start event on initial load */
-    this.$refs.modeler.$once('parsed', this.$refs.modeler.addStartEvent);
+    this.$refs.modeler.$once('parsed', () => this.$refs.modeler.addStartEvent());
 
     window.ProcessMaker.EventBus.$on('alert', alerts => this.alerts = alerts);
   },

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -534,7 +534,7 @@ export default {
       }
 
       // Add to our processNode
-      const definition = this.nodeRegistry[type].definition(this.moddle);
+      const definition = this.nodeRegistry[type].definition(this.moddle, this.$t);
 
       // Now, let's modify planeElement
       const diagram = this.nodeRegistry[type].diagram(this.moddle);
@@ -677,7 +677,7 @@ export default {
         return;
       }
 
-      const definition = startEvent.definition(this.moddle);
+      const definition = startEvent.definition(this.moddle, this.$t);
       const diagram = startEvent.diagram(this.moddle);
 
       diagram.bounds.x = 150;
@@ -741,6 +741,7 @@ export default {
     },
   },
   created() {
+    this.$t = this.$t.bind(this);
     this.registerNode(Process);
 
     /* Initialize the BpmnModdle and its extensions */

--- a/src/components/nodes/callActivity/index.js
+++ b/src/components/nodes/callActivity/index.js
@@ -2,7 +2,6 @@ import component from './callActivity';
 import CallActivityFormSelect from './CallActivityFormSelect';
 export const taskHeight = 76;
 export const id = 'processmaker-modeler-call-activity';
-import i18next from 'i18next';
 
 export default {
   id,
@@ -12,9 +11,9 @@ export default {
   category: 'BPMN',
   icon: require('@/assets/toolpanel/callActivity.svg'),
   label: 'Call Activity',
-  definition(moddle) {
+  definition(moddle, $t) {
     return moddle.create('bpmn:CallActivity', {
-      name: i18next.t('New Call Activity'),
+      name: $t('New Call Activity'),
       calledElement: '',
     });
   },

--- a/src/components/nodes/endEvent/index.js
+++ b/src/components/nodes/endEvent/index.js
@@ -1,6 +1,5 @@
 
 import component from './endEvent.vue';
-import i18next from 'i18next';
 
 export default {
   id: 'processmaker-modeler-end-event',
@@ -10,9 +9,9 @@ export default {
   category: 'BPMN',
   icon: require('@/assets/toolpanel/end-event.svg'),
   label: 'End Event',
-  definition(moddle) {
+  definition(moddle, $t) {
     return moddle.create('bpmn:EndEvent', {
-      name: i18next.t('End Event'),
+      name: $t('End Event'),
     });
   },
   diagram(moddle) {

--- a/src/components/nodes/eventBasedGateway/index.js
+++ b/src/components/nodes/eventBasedGateway/index.js
@@ -1,5 +1,4 @@
 import component from './eventBasedGateway.vue';
-import i18next from 'i18next';
 
 export default {
   id: 'processmaker-modeler-event-based-gateway',
@@ -9,9 +8,9 @@ export default {
   category: 'BPMN',
   icon: require('@/assets/toolpanel/event-based-gateway.svg'),
   label: 'Event-based Gateway',
-  definition(moddle) {
+  definition(moddle, $t) {
     return moddle.create('bpmn:EventBasedGateway', {
-      name: i18next.t('New Event-Based Gateway'),
+      name: $t('New Event-Based Gateway'),
     });
   },
   diagram(moddle) {

--- a/src/components/nodes/exclusiveGateway/index.js
+++ b/src/components/nodes/exclusiveGateway/index.js
@@ -1,5 +1,4 @@
 import component from './exclusiveGateway.vue';
-import i18next from 'i18next';
 
 export default {
   id: 'processmaker-modeler-exclusive-gateway',
@@ -9,9 +8,9 @@ export default {
   category: 'BPMN',
   icon: require('@/assets/toolpanel/exclusive-gateway.svg'),
   label: 'Exclusive Gateway',
-  definition(moddle) {
+  definition(moddle, $t) {
     return moddle.create('bpmn:ExclusiveGateway', {
-      name: i18next.t('New Exclusive Gateway'),
+      name: $t('New Exclusive Gateway'),
     });
   },
   diagram(moddle) {

--- a/src/components/nodes/gateway/index.js
+++ b/src/components/nodes/gateway/index.js
@@ -1,5 +1,4 @@
 import component from './gateway.vue';
-import i18next from 'i18next';
 
 export default {
   id: 'processmaker-modeler-gateway',
@@ -8,9 +7,9 @@ export default {
   control: true,
   category: 'BPMN',
   label: 'Gateway',
-  definition(moddle) {
+  definition(moddle, $t) {
     return moddle.create('bpmn:Gateway', {
-      name: i18next.t('New Gateway'),
+      name: $t('New Gateway'),
     });
   },
   diagram(moddle) {

--- a/src/components/nodes/inclusiveGateway/index.js
+++ b/src/components/nodes/inclusiveGateway/index.js
@@ -1,6 +1,5 @@
 import component from './inclusiveGateway.vue';
 import { gatewayDirection } from '../gateway/gatewayConfig';
-import i18next from 'i18next';
 
 export default {
   id: 'processmaker-modeler-inclusive-gateway',
@@ -10,9 +9,9 @@ export default {
   category: 'BPMN',
   icon: require('@/assets/toolpanel/inclusive-gateway.svg'),
   label: 'Inclusive Gateway',
-  definition(moddle) {
+  definition(moddle, $t) {
     return moddle.create('bpmn:InclusiveGateway', {
-      name: i18next.t('New Inclusive Gateway'),
+      name: $t('New Inclusive Gateway'),
       gatewayDirection: gatewayDirection.diverging,
     });
   },

--- a/src/components/nodes/intermediateMessageCatchEvent/index.js
+++ b/src/components/nodes/intermediateMessageCatchEvent/index.js
@@ -1,6 +1,5 @@
 import component from './intermediateMessageCatchEvent.vue';
 import omit from 'lodash/omit';
-import i18next from 'i18next';
 
 export default {
   id: 'processmaker-modeler-intermediate-message-catch-event',
@@ -10,9 +9,9 @@ export default {
   category: 'BPMN',
   icon: require('@/assets/toolpanel/intermediate-mail-event.svg'),
   label: 'Intermediate Message Catch Event',
-  definition(moddle) {
+  definition(moddle, $t) {
     return moddle.create('bpmn:IntermediateCatchEvent', {
-      name: i18next.t('Intermediate Message Catch Event'),
+      name: $t('Intermediate Message Catch Event'),
       allowedUsers: '',
       allowedGroups: '',
       whitelist: '',

--- a/src/components/nodes/intermediateTimerEvent/index.js
+++ b/src/components/nodes/intermediateTimerEvent/index.js
@@ -1,6 +1,5 @@
 import component from './intermediateTimerEvent.vue';
 import IntermediateTimer from '../../inspectors/IntermediateTimer.vue';
-import i18next from 'i18next';
 
 export default {
   id: 'processmaker-modeler-intermediate-catch-timer-event',
@@ -10,9 +9,9 @@ export default {
   category: 'BPMN',
   icon: require('@/assets/toolpanel/intermediate-time-event.svg'),
   label: 'Intermediate Timer Event',
-  definition(moddle) {
+  definition(moddle, $t) {
     return moddle.create('bpmn:IntermediateCatchEvent', {
-      name: i18next.t('Intermediate Timer Event'),
+      name: $t('Intermediate Timer Event'),
       eventDefinitions: [
         moddle.create('bpmn:TimerEventDefinition', {
           timeDuration: moddle.create('bpmn:Expression', {

--- a/src/components/nodes/manualTask/index.js
+++ b/src/components/nodes/manualTask/index.js
@@ -1,5 +1,4 @@
 import component from './manualTask.vue';
-import i18next from 'i18next';
 
 export const taskHeight = 76;
 
@@ -11,9 +10,9 @@ export default {
   category: 'BPMN',
   icon: require('@/assets/toolpanel/manualTask.svg'),
   label: 'Manual Task',
-  definition(moddle) {
+  definition(moddle, $t) {
     return moddle.create('bpmn:ManualTask', {
-      name: i18next.t('New Manual Task'),
+      name: $t('New Manual Task'),
     });
   },
   diagram(moddle) {

--- a/src/components/nodes/parallelGateway/index.js
+++ b/src/components/nodes/parallelGateway/index.js
@@ -1,6 +1,5 @@
 import component from './parallelGateway.vue';
 import { gatewayDirection } from '../gateway/gatewayConfig';
-import i18next from 'i18next';
 
 export default {
   id: 'processmaker-modeler-parallel-gateway',
@@ -10,9 +9,9 @@ export default {
   category: 'BPMN',
   icon: require('@/assets/toolpanel/parallel-gateway.svg'),
   label: 'Parallel Gateway',
-  definition(moddle) {
+  definition(moddle, $t) {
     return moddle.create('bpmn:ParallelGateway', {
-      name: i18next.t('New Parallel Gateway'),
+      name: $t('New Parallel Gateway'),
       gatewayDirection: gatewayDirection.diverging,
     });
   },

--- a/src/components/nodes/pool/index.js
+++ b/src/components/nodes/pool/index.js
@@ -1,5 +1,4 @@
 import component from './pool';
-import i18next from 'i18next';
 
 export const id = 'processmaker-modeler-pool';
 
@@ -11,9 +10,9 @@ export default {
   category: 'BPMN',
   icon: require('@/assets/toolpanel/pool.svg'),
   label: 'Pool',
-  definition(moddle) {
+  definition(moddle, $t) {
     return moddle.create('bpmn:Participant', {
-      name: i18next.t('New Pool'),
+      name: $t('New Pool'),
     });
   },
   diagram(moddle) {

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -126,7 +126,7 @@ export default {
       if (!this.laneSet) {
         this.createLaneSet();
 
-        const definition = Lane.definition(this.moddle);
+        const definition = Lane.definition(this.moddle, this.$t);
 
         /* If there are currently elements in the pool, add them to the first lane */
         this.shape.getEmbeddedCells().filter(element => {
@@ -149,7 +149,7 @@ export default {
       this.laneSet = laneSet;
       this.containingProcess.get('laneSets').push(laneSet);
     },
-    pushNewLane(definition = Lane.definition(this.moddle)) {
+    pushNewLane(definition = Lane.definition(this.moddle, this.$t)) {
       this.$emit('set-pool-target', this.shape);
 
       const diagram = Lane.diagram(this.moddle);
@@ -583,6 +583,9 @@ export default {
     } else {
       pull(this.rootElements, this.containingProcess);
     }
+  },
+  created() {
+    this.$t = this.$t.bind(this);
   },
 };
 </script>

--- a/src/components/nodes/scriptTask/index.js
+++ b/src/components/nodes/scriptTask/index.js
@@ -1,5 +1,4 @@
 import component from './scriptTask.vue';
-import i18next from 'i18next';
 
 export const taskHeight = 76;
 
@@ -11,9 +10,9 @@ export default {
   category: 'BPMN',
   icon: require('@/assets/toolpanel/scriptTask.svg'),
   label: 'Script Task',
-  definition(moddle) {
+  definition(moddle, $t) {
     return moddle.create('bpmn:ScriptTask', {
-      name: i18next.t('New Script Task'),
+      name: $t('New Script Task'),
     });
   },
   diagram(moddle) {

--- a/src/components/nodes/sequenceFlow/index.js
+++ b/src/components/nodes/sequenceFlow/index.js
@@ -1,5 +1,4 @@
 import component from './sequenceFlow.vue';
-import i18next from 'i18next';
 
 export const id = 'processmaker-modeler-sequence-flow';
 
@@ -8,9 +7,9 @@ export default {
   component,
   bpmnType: 'bpmn:SequenceFlow',
   control: false,
-  definition(moddle) {
+  definition(moddle, $t) {
     return moddle.create('bpmn:SequenceFlow', {
-      name: i18next.t('New Sequence Flow'),
+      name: $t('New Sequence Flow'),
       startEvent: '',
     });
   },

--- a/src/components/nodes/serviceTask/index.js
+++ b/src/components/nodes/serviceTask/index.js
@@ -1,5 +1,4 @@
 import taskConfig from '@/components/nodes/task';
-import i18next from 'i18next';
 
 export default {
   ...taskConfig,
@@ -7,9 +6,9 @@ export default {
   bpmnType: ['bpmn:ServiceTask', 'bpmn:SendTask', 'bpmn:ReceiveTask'],
   control: false,
   label: 'Service Task',
-  definition(moddle) {
+  definition(moddle, $t) {
     return moddle.create('bpmn:ServiceTask', {
-      name: i18next.t('New Service Task'),
+      name: $t('New Service Task'),
     });
   },
   inspectorConfig: [

--- a/src/components/nodes/startEvent/index.js
+++ b/src/components/nodes/startEvent/index.js
@@ -1,5 +1,4 @@
 import component from './startEvent.vue';
-import i18next from 'i18next';
 
 export default {
   id: 'processmaker-modeler-start-event',
@@ -9,9 +8,9 @@ export default {
   category: 'BPMN',
   icon: require('@/assets/toolpanel/start-event.svg'),
   label: 'Start Event',
-  definition(moddle) {
+  definition(moddle, $t) {
     return moddle.create('bpmn:StartEvent', {
-      name: i18next.t('Start Event'),
+      name: $t('Start Event'),
     });
   },
   diagram(moddle) {

--- a/src/components/nodes/startTimerEvent/index.js
+++ b/src/components/nodes/startTimerEvent/index.js
@@ -1,7 +1,6 @@
 import component from './startTimerEvent.vue';
 import TimerExpression from '../../inspectors/TimerExpression.vue';
 import { DateTime } from 'luxon';
-import i18next from 'i18next';
 
 export default {
   id: 'processmaker-modeler-start-timer-event',
@@ -11,9 +10,9 @@ export default {
   category: 'BPMN',
   icon: require('@/assets/toolpanel/start-timer-event.svg'),
   label: 'Start Timer Event',
-  definition(moddle) {
+  definition(moddle, $t) {
     let startEventDefinition = moddle.create('bpmn:StartEvent', {
-      name: i18next.t('Start Timer Event'),
+      name: $t('Start Timer Event'),
     });
 
     startEventDefinition.eventDefinitions = [moddle.create('bpmn:TimerEventDefinition', {

--- a/src/components/nodes/task/index.js
+++ b/src/components/nodes/task/index.js
@@ -1,5 +1,4 @@
 import component from './task.vue';
-import i18next from 'i18next';
 
 export const taskHeight = 76;
 
@@ -11,9 +10,9 @@ export default {
   category: 'BPMN',
   icon: require('@/assets/toolpanel/task.svg'),
   label: 'Task',
-  definition(moddle) {
+  definition(moddle, $t) {
     return moddle.create('bpmn:Task', {
-      name: i18next.t('Task'),
+      name: $t('Task'),
     });
   },
   diagram(moddle) {

--- a/src/components/nodes/textAnnotation/index.js
+++ b/src/components/nodes/textAnnotation/index.js
@@ -1,5 +1,4 @@
 import component from './textAnnotation.vue';
-import i18next from 'i18next';
 
 export const textAnnotationWidth = 150;
 export const labelPadding = 15;
@@ -12,9 +11,9 @@ export default {
   category: 'BPMN',
   icon: require('@/assets/toolpanel/text-annotation.svg'),
   label: 'Text Annotation',
-  definition(moddle) {
+  definition(moddle, $t) {
     return moddle.create('bpmn:TextAnnotation', {
-      text: i18next.t('New Text Annotation'),
+      text: $t('New Text Annotation'),
     });
   },
   diagram(moddle) {

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -96,7 +96,7 @@ export default {
     addSequence(cellView, evt, x, y) {
       this.removeCrown();
       const sequenceFlowConfig = this.nodeRegistry['processmaker-modeler-sequence-flow'];
-      const sequenceLink = sequenceFlowConfig.definition(this.moddle);
+      const sequenceLink = sequenceFlowConfig.definition(this.moddle, this.$t);
       sequenceLink.set('sourceRef', this.node.definition);
       sequenceLink.set('targetRef', { x, y });
 
@@ -312,6 +312,9 @@ export default {
         this.collaboration.get('messageFlows').push(this.node.definition);
       }
     });
+  },
+  created() {
+    this.$t = this.$t.bind(this);
   },
   destroyed() {
     this.shape.stopListening();


### PR DESCRIPTION
Fix translations by passing in reference to `$t` to node creation.
Link to video of fix working in spark: https://www.dropbox.com/s/ufj9zrptjonhe66/translations_working.mov?dl=0