### PR TITLE
Bugfix: Validation error intermediate message catch event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1212,9 +1212,9 @@
       }
     },
     "@processmaker/processmaker-bpmn-moddle": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@processmaker/processmaker-bpmn-moddle/-/processmaker-bpmn-moddle-0.4.0.tgz",
-      "integrity": "sha512-oz6Zl3OBvJ4DhsQYEf1p9z1HDZrAEBopAKJSoYIpvU5WhKjnJNl7gmFPuCT2NZwUN+dqSSAOB7cusum7YamH/g==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@processmaker/processmaker-bpmn-moddle/-/processmaker-bpmn-moddle-0.4.1.tgz",
+      "integrity": "sha512-zWA41KwxDcKG/8mQ5RKpA2QPIoATMTZp9IU0ewx7Z2QwPmTugSkK8ZPdfvSK46DqX39ejZI4EFo+PTTGfZDiuw==",
       "dev": true,
       "requires": {
         "min-dash": "^3.0.0"
@@ -7418,8 +7418,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7440,14 +7439,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7462,20 +7459,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7592,8 +7586,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7605,7 +7598,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7620,7 +7612,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7628,14 +7619,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7654,7 +7643,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7735,8 +7723,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7748,7 +7735,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7834,8 +7820,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7871,7 +7856,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7891,7 +7875,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7935,14 +7918,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -8933,8 +8914,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
@@ -8991,7 +8971,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -18153,8 +18132,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
@@ -19699,8 +19677,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@panter/vue-i18next": "^0.15.0",
-    "@processmaker/processmaker-bpmn-moddle": "^0.4.0",
+    "@processmaker/processmaker-bpmn-moddle": "^0.4.1",
     "@vue/cli-plugin-babel": "^3.0.5",
     "@vue/cli-plugin-e2e-cypress": "^3.4.0",
     "@vue/cli-plugin-eslint": "^3.0.5",

--- a/src/components/nodes/intermediateMessageCatchEvent/index.js
+++ b/src/components/nodes/intermediateMessageCatchEvent/index.js
@@ -17,8 +17,8 @@ export default {
       whitelist: '',
       eventDefinitions: [
         moddle.create('bpmn:MessageEventDefinition', {
-          id: '',
-          variableName: '',
+          id: 'message_event_1',
+          variableName: 'message',
         }),
       ],
     });

--- a/src/components/nodes/intermediateMessageCatchEvent/index.js
+++ b/src/components/nodes/intermediateMessageCatchEvent/index.js
@@ -102,6 +102,7 @@ export default {
                 label: 'Message Event Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'eventDefinitionId',
+                validation: 'required',
               },
             },
             {

--- a/tests/e2e/fixtures/parser.xml
+++ b/tests/e2e/fixtures/parser.xml
@@ -13,7 +13,7 @@
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
     <bpmn:intermediateCatchEvent id="node_4" name="Intermediate Message Catch Event" pm:whitelist="">
-      <bpmn:messageEventDefinition id="" variableName="" />
+      <bpmn:messageEventDefinition id="" pm:variableName="" />
     </bpmn:intermediateCatchEvent>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">

--- a/tests/e2e/specs/IntermediateMessageCatchEvent.spec.js
+++ b/tests/e2e/specs/IntermediateMessageCatchEvent.spec.js
@@ -35,7 +35,7 @@ describe('Intermediate Message Catch Event', () => {
 
     const validXML =
     `<bpmn:intermediateCatchEvent id="node_2" name="${name}" pm:allowedUsers="1,10" pm:allowedGroups="20,30" pm:whitelist="${whiteList}">
-      <bpmn:messageEventDefinition id="${eventId}" variableName="${variableName}" />
+      <bpmn:messageEventDefinition id="${eventId}" pm:variableName="${variableName}" />
     </bpmn:intermediateCatchEvent>`;
 
     cy.get('[data-test=downloadXMLBtn]').click();


### PR DESCRIPTION
- Updated `processmaker-bpmn-moddle` to 0.4.1
- Requires update `processmaker-bpmn-moddle` to 0.4.1 in Spark 
  - PR to update package in Spark (https://github.com/ProcessMaker/spark/issues/1945)
- Added defaults for message event definition id and message
- messageEventDefinitionId is required

**How to test**
- Drag intermediate message catch event
- Click save
Expected: Bpmn diagram saves without any errors
_________________
- Clear message event id field
- attempt to save
Expected: Error Message appears and user cannot save diagram

**Spark-Modeler**
https://drive.google.com/open?id=1wjPESKOJmDmZIjwYqy2XsQqB_AIJiJkt

Fixes #407 