### PR TITLE
Validation to ids in QName format

### DIFF
--- a/src/components/inspectors/configId.js
+++ b/src/components/inspectors/configId.js
@@ -1,4 +1,5 @@
 export const configId  = {
   id: 'id',
   validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+  helper: 'The id field should be unique across all elements in the diagram, ex. id_1.',
 };

--- a/src/components/inspectors/configId.js
+++ b/src/components/inspectors/configId.js
@@ -1,0 +1,4 @@
+export const configId  = {
+  id: 'id',
+  validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+};

--- a/src/components/inspectors/process.js
+++ b/src/components/inspectors/process.js
@@ -1,3 +1,5 @@
+import { configId } from './configId';
+
 export default {
   id: 'processmaker-modeler-process',
   bpmnType: 'bpmn:Process',
@@ -21,9 +23,9 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                helper: configId.helper,
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/inspectors/process.js
+++ b/src/components/inspectors/process.js
@@ -7,12 +7,6 @@ export default {
     {
       name: 'Process Information',
       items: [
-        // {
-        //   component: 'FormText',
-        //   config: {
-        //     label: 'Process',
-        //   },
-        // },
         {
           component: 'FormAccordion',
           container: true,

--- a/src/components/inspectors/process.js
+++ b/src/components/inspectors/process.js
@@ -23,6 +23,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/association/index.js
+++ b/src/components/nodes/association/index.js
@@ -1,5 +1,6 @@
 import component from './association.vue';
 import { direction } from './associationConfig';
+import { configId } from '@/components/inspectors/configId';
 
 export const id  = 'processmaker-modeler-association';
 
@@ -32,8 +33,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/association/index.js
+++ b/src/components/nodes/association/index.js
@@ -33,6 +33,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/association/index.js
+++ b/src/components/nodes/association/index.js
@@ -32,7 +32,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/components/nodes/callActivity/index.js
+++ b/src/components/nodes/callActivity/index.js
@@ -2,6 +2,7 @@ import component from './callActivity';
 import CallActivityFormSelect from './CallActivityFormSelect';
 export const taskHeight = 76;
 export const id = 'processmaker-modeler-call-activity';
+import { configId } from '@/components/inspectors/configId';
 
 export default {
   id,
@@ -58,8 +59,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/callActivity/index.js
+++ b/src/components/nodes/callActivity/index.js
@@ -58,7 +58,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/components/nodes/callActivity/index.js
+++ b/src/components/nodes/callActivity/index.js
@@ -59,6 +59,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/endEvent/index.js
+++ b/src/components/nodes/endEvent/index.js
@@ -51,7 +51,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/components/nodes/endEvent/index.js
+++ b/src/components/nodes/endEvent/index.js
@@ -1,5 +1,6 @@
 
 import component from './endEvent.vue';
+import { configId } from '@/components/inspectors/configId';
 
 export default {
   id: 'processmaker-modeler-end-event',
@@ -51,8 +52,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/endEvent/index.js
+++ b/src/components/nodes/endEvent/index.js
@@ -52,6 +52,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/eventBasedGateway/index.js
+++ b/src/components/nodes/eventBasedGateway/index.js
@@ -41,6 +41,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/eventBasedGateway/index.js
+++ b/src/components/nodes/eventBasedGateway/index.js
@@ -1,4 +1,5 @@
 import component from './eventBasedGateway.vue';
+import { configId } from '@/components/inspectors/configId';
 
 export default {
   id: 'processmaker-modeler-event-based-gateway',
@@ -40,8 +41,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/eventBasedGateway/index.js
+++ b/src/components/nodes/eventBasedGateway/index.js
@@ -40,7 +40,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/components/nodes/exclusiveGateway/index.js
+++ b/src/components/nodes/exclusiveGateway/index.js
@@ -41,6 +41,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/exclusiveGateway/index.js
+++ b/src/components/nodes/exclusiveGateway/index.js
@@ -1,4 +1,5 @@
 import component from './exclusiveGateway.vue';
+import { configId } from '@/components/inspectors/configId';
 
 export default {
   id: 'processmaker-modeler-exclusive-gateway',
@@ -40,8 +41,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/exclusiveGateway/index.js
+++ b/src/components/nodes/exclusiveGateway/index.js
@@ -40,7 +40,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/components/nodes/gateway/index.js
+++ b/src/components/nodes/gateway/index.js
@@ -40,6 +40,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/gateway/index.js
+++ b/src/components/nodes/gateway/index.js
@@ -39,7 +39,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/components/nodes/gateway/index.js
+++ b/src/components/nodes/gateway/index.js
@@ -1,4 +1,5 @@
 import component from './gateway.vue';
+import { configId } from '@/components/inspectors/configId';
 
 export default {
   id: 'processmaker-modeler-gateway',
@@ -39,8 +40,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/inclusiveGateway/index.js
+++ b/src/components/nodes/inclusiveGateway/index.js
@@ -1,5 +1,6 @@
 import component from './inclusiveGateway.vue';
 import { gatewayDirection } from '../gateway/gatewayConfig';
+import { configId } from '@/components/inspectors/configId';
 
 export default {
   id: 'processmaker-modeler-inclusive-gateway',
@@ -42,8 +43,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/inclusiveGateway/index.js
+++ b/src/components/nodes/inclusiveGateway/index.js
@@ -42,7 +42,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/components/nodes/inclusiveGateway/index.js
+++ b/src/components/nodes/inclusiveGateway/index.js
@@ -43,6 +43,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/intermediateMessageCatchEvent/index.js
+++ b/src/components/nodes/intermediateMessageCatchEvent/index.js
@@ -1,5 +1,6 @@
 import component from './intermediateMessageCatchEvent.vue';
 import omit from 'lodash/omit';
+import { configId } from '@/components/inspectors/configId';
 
 export default {
   id: 'processmaker-modeler-intermediate-message-catch-event',
@@ -85,8 +86,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/intermediateMessageCatchEvent/index.js
+++ b/src/components/nodes/intermediateMessageCatchEvent/index.js
@@ -85,7 +85,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/components/nodes/intermediateMessageCatchEvent/index.js
+++ b/src/components/nodes/intermediateMessageCatchEvent/index.js
@@ -86,6 +86,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/intermediateTimerEvent/index.js
+++ b/src/components/nodes/intermediateTimerEvent/index.js
@@ -100,6 +100,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/intermediateTimerEvent/index.js
+++ b/src/components/nodes/intermediateTimerEvent/index.js
@@ -1,5 +1,6 @@
 import component from './intermediateTimerEvent.vue';
 import IntermediateTimer from '../../inspectors/IntermediateTimer.vue';
+import { configId } from '@/components/inspectors/configId';
 
 export default {
   id: 'processmaker-modeler-intermediate-catch-timer-event',
@@ -78,12 +79,6 @@ export default {
     {
       name: 'Intermediate Timer Event',
       items: [
-        // {
-        //   component: 'FormText',
-        //   config: {
-        //     label: 'Intermediate Timer Event',
-        //   },
-        // },
         {
           component: 'FormAccordion',
           container: true,
@@ -99,8 +94,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/intermediateTimerEvent/index.js
+++ b/src/components/nodes/intermediateTimerEvent/index.js
@@ -93,7 +93,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/components/nodes/manualTask/index.js
+++ b/src/components/nodes/manualTask/index.js
@@ -1,4 +1,5 @@
 import component from './manualTask.vue';
+import { configId } from '@/components/inspectors/configId';
 
 export const taskHeight = 76;
 
@@ -42,8 +43,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/manualTask/index.js
+++ b/src/components/nodes/manualTask/index.js
@@ -42,7 +42,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/components/nodes/manualTask/index.js
+++ b/src/components/nodes/manualTask/index.js
@@ -43,6 +43,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/messageFlow/index.js
+++ b/src/components/nodes/messageFlow/index.js
@@ -1,4 +1,5 @@
 import component from './messageFlow.vue';
+import { configId } from '@/components/inspectors/configId';
 
 export const id = 'processmaker-modeler-message-flow';
 
@@ -29,8 +30,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/messageFlow/index.js
+++ b/src/components/nodes/messageFlow/index.js
@@ -30,6 +30,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/messageFlow/index.js
+++ b/src/components/nodes/messageFlow/index.js
@@ -29,7 +29,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/components/nodes/parallelGateway/index.js
+++ b/src/components/nodes/parallelGateway/index.js
@@ -42,7 +42,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/components/nodes/parallelGateway/index.js
+++ b/src/components/nodes/parallelGateway/index.js
@@ -43,6 +43,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/parallelGateway/index.js
+++ b/src/components/nodes/parallelGateway/index.js
@@ -1,5 +1,6 @@
 import component from './parallelGateway.vue';
 import { gatewayDirection } from '../gateway/gatewayConfig';
+import { configId } from '@/components/inspectors/configId';
 
 export default {
   id: 'processmaker-modeler-parallel-gateway',
@@ -42,8 +43,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/pool/index.js
+++ b/src/components/nodes/pool/index.js
@@ -1,4 +1,5 @@
 import component from './pool';
+import { configId } from '@/components/inspectors/configId';
 
 export const id = 'processmaker-modeler-pool';
 
@@ -42,8 +43,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/pool/index.js
+++ b/src/components/nodes/pool/index.js
@@ -42,7 +42,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/components/nodes/pool/index.js
+++ b/src/components/nodes/pool/index.js
@@ -43,6 +43,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/poolLane/index.js
+++ b/src/components/nodes/poolLane/index.js
@@ -39,6 +39,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/poolLane/index.js
+++ b/src/components/nodes/poolLane/index.js
@@ -2,6 +2,7 @@ import component from './poolLane';
 
 export const id = 'processmaker-modeler-lane';
 export const minLaneHeight = 100;
+import { configId } from '@/components/inspectors/configId';
 
 export default {
   id,
@@ -38,8 +39,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/poolLane/index.js
+++ b/src/components/nodes/poolLane/index.js
@@ -37,8 +37,8 @@ export default {
             {
               component: 'FormInput',
               config: {
-                label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                label: configId.helper,
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/components/nodes/scriptTask/index.js
+++ b/src/components/nodes/scriptTask/index.js
@@ -43,6 +43,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/scriptTask/index.js
+++ b/src/components/nodes/scriptTask/index.js
@@ -1,6 +1,7 @@
 import component from './scriptTask.vue';
 
 export const taskHeight = 76;
+import { configId } from '@/components/inspectors/configId';
 
 export default {
   id: 'processmaker-modeler-script-task',
@@ -42,8 +43,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/sequenceFlow/index.js
+++ b/src/components/nodes/sequenceFlow/index.js
@@ -68,6 +68,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/sequenceFlow/index.js
+++ b/src/components/nodes/sequenceFlow/index.js
@@ -1,6 +1,7 @@
 import component from './sequenceFlow.vue';
 
 export const id = 'processmaker-modeler-sequence-flow';
+import { configId } from '@/components/inspectors/configId';
 
 export default {
   id,
@@ -67,8 +68,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/sequenceFlow/index.js
+++ b/src/components/nodes/sequenceFlow/index.js
@@ -67,7 +67,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/components/nodes/startEvent/index.js
+++ b/src/components/nodes/startEvent/index.js
@@ -1,4 +1,5 @@
 import component from './startEvent.vue';
+import { configId } from '@/components/inspectors/configId';
 
 export default {
   id: 'processmaker-modeler-start-event',
@@ -50,8 +51,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/startEvent/index.js
+++ b/src/components/nodes/startEvent/index.js
@@ -50,7 +50,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/components/nodes/startEvent/index.js
+++ b/src/components/nodes/startEvent/index.js
@@ -51,6 +51,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/startTimerEvent/index.js
+++ b/src/components/nodes/startTimerEvent/index.js
@@ -91,7 +91,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/components/nodes/startTimerEvent/index.js
+++ b/src/components/nodes/startTimerEvent/index.js
@@ -98,6 +98,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/startTimerEvent/index.js
+++ b/src/components/nodes/startTimerEvent/index.js
@@ -1,6 +1,7 @@
 import component from './startTimerEvent.vue';
 import TimerExpression from '../../inspectors/TimerExpression.vue';
 import { DateTime } from 'luxon';
+import { configId } from '@/components/inspectors/configId';
 
 export default {
   id: 'processmaker-modeler-start-timer-event',
@@ -76,12 +77,6 @@ export default {
     {
       name: 'Start Timer Event',
       items: [
-        // {
-        //   component: 'FormText',
-        //   config: {
-        //     label: 'Start Timer Event',
-        //   },
-        // },
         {
           component: 'FormAccordion',
           container: true,
@@ -97,8 +92,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/task/index.js
+++ b/src/components/nodes/task/index.js
@@ -1,6 +1,7 @@
 import component from './task.vue';
 
 export const taskHeight = 76;
+import { configId } from '@/components/inspectors/configId';
 
 export default {
   id: 'processmaker-modeler-task',
@@ -42,8 +43,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/task/index.js
+++ b/src/components/nodes/task/index.js
@@ -42,7 +42,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/components/nodes/task/index.js
+++ b/src/components/nodes/task/index.js
@@ -43,6 +43,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/textAnnotation/index.js
+++ b/src/components/nodes/textAnnotation/index.js
@@ -2,6 +2,7 @@ import component from './textAnnotation.vue';
 
 export const textAnnotationWidth = 150;
 export const labelPadding = 15;
+import { configId } from '@/components/inspectors/configId';
 
 export default {
   id: 'processmaker-modeler-text-annotation',
@@ -59,8 +60,8 @@ export default {
               config: {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
-                name: 'id',
-                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+                name: configId.id,
+                validation: configId.validation,
               },
             },
             {

--- a/src/components/nodes/textAnnotation/index.js
+++ b/src/components/nodes/textAnnotation/index.js
@@ -60,6 +60,7 @@ export default {
                 label: 'Identifier',
                 helper: 'The id field should be unique across all elements in the diagram',
                 name: 'id',
+                validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
               },
             },
             {

--- a/src/components/nodes/textAnnotation/index.js
+++ b/src/components/nodes/textAnnotation/index.js
@@ -59,7 +59,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: configId.helper,
                 name: configId.id,
                 validation: configId.validation,
               },

--- a/src/setup/extensions/scriptTask.js
+++ b/src/setup/extensions/scriptTask.js
@@ -52,6 +52,7 @@ window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode }) => {
               label: 'Identifier',
               helper: 'The id field should be unique across all elements in the diagram',
               name: 'id',
+              validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
             },
           },
           {

--- a/src/setup/extensions/testCustomConnector.js
+++ b/src/setup/extensions/testCustomConnector.js
@@ -92,6 +92,7 @@ window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode }) => {
               label: 'Identifier',
               helper: 'The id field should be unique across all elements in the diagram',
               name: 'id',
+              validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
             },
           },
           {

--- a/src/setup/extensions/twitterConnector.js
+++ b/src/setup/extensions/twitterConnector.js
@@ -88,6 +88,7 @@ window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode }) => {
               label: 'Identifier',
               helper: 'The id field should be unique across all elements in the diagram',
               name: 'id',
+              validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
             },
           },
           {

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -272,4 +272,18 @@ describe('Modeler', () => {
     cy.get('.paper-container').trigger('mouseup');
     cy.get('.ignore-pointer').should('have.length', 0);
   });
+
+  it('check if process id is a valid QName', () => {
+    cy.get('[name=id]').clear();
+
+    const invalidId = '12 id!';
+    typeIntoTextInput('[name=id]', invalidId);
+
+    cy.get('.invalid-feedback').should('contain', 'The id format is invalid.');
+
+    const validId = 'Process_1';
+    typeIntoTextInput('[name=id]', validId);
+
+    cy.get('.invalid-feedback').should('not.have.value', 'The id format is invalid.');
+  });
 });


### PR DESCRIPTION
**CheckList**
- [x] Test manually in Spark
- [x] Video Demo created
- [x] Created automated test
- [x] Automated test passes locally

- Add Validation to inspector ids
- ids required to be in `QName` format
- Change helper text to have an example of valid QName

```
QName on page 477 (507 in PDF):

The BPMN XSD utilizes IDREFs wherever possible and resorts to QName 
only when references can span files. In both situations however, the reference is still based on IDs.

QNames can't have spaces or start with numbers.
```
[BPMNSPEC-11-01-03 (1).pdf](https://github.com/ProcessMaker/spark-modeler/files/3257725/BPMNSPEC-11-01-03.1.pdf)

**Spark Video Demo**
https://drive.google.com/open?id=1kVZ0n4zwAmy28LS7E-WfcTRkPSoAkQV4

Fixes #323 