### PR TITLE
Fix inspector height

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "lint": "vue-cli-service lint --no-fix",
     "lint-fix": "vue-cli-service lint",
     "test": "vue-cli-service test:e2e",
-    "test-ci": "vue-cli-service test:e2e --headless --browser chrome",
-    "postinstall": "npm run build-bundle"
+    "test-ci": "vue-cli-service test:e2e --headless --browser chrome"
   },
   "main": "./dist/modeler.common.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "vue-cli-service lint --no-fix",
     "lint-fix": "vue-cli-service lint",
     "test": "vue-cli-service test:e2e",
-    "test-ci": "vue-cli-service test:e2e --headless --browser chrome"
+    "test-ci": "vue-cli-service test:e2e --headless --browser chrome",
+    "postinstall": "npm run build-bundle"
   },
   "main": "./dist/modeler.common.js",
   "files": [

--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -6,7 +6,7 @@
       :data="data"
       @update="updateDefinition"
       :config="config"
-      class="overflow-auto"
+      class="overflow-auto h-100"
       @focusout.native="updateState"
       ref="formRenderer"
     />


### PR DESCRIPTION
Set inspector renderer container to height: 100%

**Spark Video Demo**
https://drive.google.com/open?id=1AZ5x0ZeuDnOl1cwcuGX8AgdrvPrVzG0w

Fixes #425 