### PR TITLE
Unqiue id message event

### DIFF
--- a/src/MessageEventIdGenerator.js
+++ b/src/MessageEventIdGenerator.js
@@ -1,0 +1,35 @@
+import  NodeIdGenerator from './NodeIdGenerator';
+import store from '@/store';
+
+export default class MessageEventIdGenerator extends NodeIdGenerator {
+  constructor(definitions) {
+    super(definitions);
+  }
+
+
+  generateNewMessageEventId() {
+    let id = super.generateNewNodeId('message_event_');
+
+    while (this.isIdUnique(id)) {
+      id = this.generateNewMessageEventId();
+    }
+
+    return id;
+  }
+
+  isIdUnique(id) {
+    const nodes = store.getters.nodes;
+
+    const eventDefinitionIdList = nodes.map(node => {
+      return node.definition;
+    }).filter(node => {
+      return node.eventDefinitions;
+    }).map(node => {
+      return node.eventDefinitions;
+    }).flat().map(messageEventDefinition => {
+      return messageEventDefinition.id;
+    });
+
+    return eventDefinitionIdList.includes(id);
+  }
+}

--- a/src/MessageEventIdGenerator.js
+++ b/src/MessageEventIdGenerator.js
@@ -1,11 +1,12 @@
 import  NodeIdGenerator from './NodeIdGenerator';
 import store from '@/store';
+import get from 'lodash/get';
 
 export default class MessageEventIdGenerator extends NodeIdGenerator {
   generateNewMessageEventId() {
     let id = super.generateNewNodeId('message_event_');
 
-    while (this.isIdUnique(id)) {
+    while (!this.isIdUnique(id)) {
       id = this.generateNewMessageEventId();
     }
 
@@ -15,16 +16,10 @@ export default class MessageEventIdGenerator extends NodeIdGenerator {
   isIdUnique(id) {
     const nodes = store.getters.nodes;
 
-    const eventDefinitionIdList = nodes.map(node => {
-      return node.definition;
-    }).filter(node => {
-      return node.eventDefinitions;
-    }).map(node => {
-      return node.eventDefinitions;
-    }).flat().map(messageEventDefinition => {
-      return messageEventDefinition.id;
-    });
+    const eventDefinitionIdList = nodes
+      .map(node => get(node, 'definition.eventDefinitions[0].id'))
+      .filter(id => id !== undefined);
 
-    return eventDefinitionIdList.includes(id);
+    return !eventDefinitionIdList.includes(id);
   }
 }

--- a/src/MessageEventIdGenerator.js
+++ b/src/MessageEventIdGenerator.js
@@ -2,11 +2,6 @@ import  NodeIdGenerator from './NodeIdGenerator';
 import store from '@/store';
 
 export default class MessageEventIdGenerator extends NodeIdGenerator {
-  constructor(definitions) {
-    super(definitions);
-  }
-
-
   generateNewMessageEventId() {
     let id = super.generateNewNodeId('message_event_');
 

--- a/src/NodeIdGenerator.js
+++ b/src/NodeIdGenerator.js
@@ -24,8 +24,10 @@ export default class NodeIdGenerator {
   }
 
   isIdUnique(id) {
-    const planeElements = this.definitions.diagrams[0].plane.get('planeElement');
+    const planeElementIds = this.definitions.diagrams[0].plane
+      .get('planeElement')
+      .map(planeElement => planeElement.get('bpmnElement').id);
 
-    return planeElements.every(planeElement => id !== planeElement.get('bpmnElement').id);
+    return !planeElementIds.includes(id);
   }
 }

--- a/src/NodeIdGenerator.js
+++ b/src/NodeIdGenerator.js
@@ -16,8 +16,8 @@ export default class NodeIdGenerator {
     return id;
   }
 
-  generateNewNodeId() {
-    const id = nodeIdPrefix + this.counter;
+  generateNewNodeId(prefix = nodeIdPrefix) {
+    const id = prefix + this.counter;
     this.counter++;
 
     return id;

--- a/src/components/nodes/intermediateMessageCatchEvent/index.js
+++ b/src/components/nodes/intermediateMessageCatchEvent/index.js
@@ -1,6 +1,9 @@
 import component from './intermediateMessageCatchEvent.vue';
 import omit from 'lodash/omit';
 import { configId } from '@/components/inspectors/configId';
+import NodeIdGenerator from '../../../NodeIdGenerator';
+
+const generateMessageEventId = new NodeIdGenerator();
 
 export default {
   id: 'processmaker-modeler-intermediate-message-catch-event',
@@ -18,7 +21,7 @@ export default {
       whitelist: '',
       eventDefinitions: [
         moddle.create('bpmn:MessageEventDefinition', {
-          id: 'message_event_1',
+          id: generateMessageEventId.generateNewNodeId('message_event_'),
           variableName: 'message',
         }),
       ],

--- a/src/components/nodes/intermediateMessageCatchEvent/index.js
+++ b/src/components/nodes/intermediateMessageCatchEvent/index.js
@@ -1,9 +1,9 @@
 import component from './intermediateMessageCatchEvent.vue';
 import omit from 'lodash/omit';
 import { configId } from '@/components/inspectors/configId';
-import NodeIdGenerator from '../../../NodeIdGenerator';
+import MessageEventIdGenerator from '../../../MessageEventIdGenerator';
 
-const generateMessageEventId = new NodeIdGenerator();
+const messageEventIdGenerator = new MessageEventIdGenerator();
 
 export default {
   id: 'processmaker-modeler-intermediate-message-catch-event',
@@ -21,7 +21,7 @@ export default {
       whitelist: '',
       eventDefinitions: [
         moddle.create('bpmn:MessageEventDefinition', {
-          id: generateMessageEventId.generateNewNodeId('message_event_'),
+          id: messageEventIdGenerator.generateNewMessageEventId(),
           variableName: 'message',
         }),
       ],

--- a/tests/e2e/fixtures/messageFlow.xml
+++ b/tests/e2e/fixtures/messageFlow.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event" />
+    <bpmn:intermediateCatchEvent id="node_2" name="Intermediate Message Catch Event" pm:whitelist="">
+      <bpmn:messageEventDefinition id="message_event_1" pm:variableName="message" />
+    </bpmn:intermediateCatchEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="150" y="150" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="290" y="310" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/e2e/specs/IntermediateMessageCatchEvent.spec.js
+++ b/tests/e2e/specs/IntermediateMessageCatchEvent.spec.js
@@ -44,4 +44,26 @@ describe('Intermediate Message Catch Event', () => {
       .then(xml => xml.trim())
       .should('contain', validXML.trim());
   });
+
+  it('Message Event Definition Ids are unique on render', () => {
+    const intermediateMessageCatchEventPosition = { x: 200, y: 200 };
+    dragFromSourceToDest(nodeTypes.intermediateMessageCatchEvent, intermediateMessageCatchEventPosition);
+
+    const intermediateMessageCatchEventSecondPosition = { x: 300, y: 300 };
+    dragFromSourceToDest(nodeTypes.intermediateMessageCatchEvent, intermediateMessageCatchEventSecondPosition);
+
+    const validXML =
+    `<bpmn:intermediateCatchEvent id="node_2" name="Intermediate Message Catch Event" pm:allowedUsers="" pm:allowedGroups="" pm:whitelist="">
+      <bpmn:messageEventDefinition id="message_event_1" pm:variableName="message" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="node_3" name="Intermediate Message Catch Event" pm:allowedUsers="" pm:allowedGroups="" pm:whitelist="">
+      <bpmn:messageEventDefinition id="message_event_2" pm:variableName="message" />
+    </bpmn:intermediateCatchEvent>`;
+
+    cy.get('[data-test=downloadXMLBtn]').click();
+    cy.window()
+      .its('xml')
+      .then(xml => xml.trim())
+      .should('contain', validXML.trim());
+  });
 });

--- a/tests/e2e/specs/IntermediateMessageCatchEvent.spec.js
+++ b/tests/e2e/specs/IntermediateMessageCatchEvent.spec.js
@@ -2,9 +2,12 @@ import {
   dragFromSourceToDest,
   typeIntoTextInput,
   getElementAtPosition,
+  waitToRenderAllShapes,
 } from '../support/utils';
 
 import { nodeTypes } from '../support/constants';
+
+const modalAnimationTime = 300;
 
 describe('Intermediate Message Catch Event', () => {
   beforeEach(() => {
@@ -65,5 +68,57 @@ describe('Intermediate Message Catch Event', () => {
       .its('xml')
       .then(xml => xml.trim())
       .should('contain', validXML.trim());
+  });
+
+  it('Generates sequential, unique messageEvent IDs', () => {
+    waitToRenderAllShapes();
+
+    const intermediateMessageCatchEventPosition = { x: 200, y: 200 };
+    dragFromSourceToDest(nodeTypes.intermediateMessageCatchEvent, intermediateMessageCatchEventPosition);
+    getElementAtPosition(intermediateMessageCatchEventPosition).click();
+
+    cy.get('[name=eventDefinitionId]').should('have.value', 'message_event_1');
+
+    typeIntoTextInput('[name=eventDefinitionId]', 'message_event_2');
+
+    const intermediateMessageCatchEvent2Position = { x: 250, y: 250 };
+    dragFromSourceToDest(nodeTypes.intermediateMessageCatchEvent, intermediateMessageCatchEvent2Position);
+    getElementAtPosition(intermediateMessageCatchEvent2Position).click();
+
+    cy.get('[name=eventDefinitionId]').should('have.value', 'message_event_3');
+
+    const intermediateMessageCatchEvent3Position = { x: 300, y: 300 };
+    dragFromSourceToDest(nodeTypes.intermediateMessageCatchEvent, intermediateMessageCatchEvent3Position);
+    getElementAtPosition(intermediateMessageCatchEvent3Position).click();
+
+    cy.get('[name=eventDefinitionId]').should('have.value', 'message_event_4');
+
+    cy.contains('Upload XML').click();
+
+    /* Wait for modal to open */
+    cy.wait(modalAnimationTime);
+
+    cy.fixture('../fixtures/messageFlow.xml', 'base64').then(blankProcess => {
+      return cy.get('input[type=file]').then($input => {
+        return Cypress.Blob.base64StringToBlob(blankProcess, 'text/xml')
+          .then((blob) => {
+            const testfile = new File([blob], 'messageFlow.xml', { type: 'text/xml' });
+            const dataTransfer = new DataTransfer();
+            dataTransfer.items.add(testfile);
+            const input = $input[0];
+            input.files = dataTransfer.files;
+            cy.wrap(input).trigger('change', { force: true });
+            return cy.get('#uploadmodal button').contains('Upload').click();
+          });
+      });
+    });
+
+    /* Wait for modal to close */
+    cy.wait(modalAnimationTime);
+
+    dragFromSourceToDest(nodeTypes.intermediateMessageCatchEvent, intermediateMessageCatchEventPosition);
+    getElementAtPosition(intermediateMessageCatchEventPosition).click();
+
+    cy.get('[name=eventDefinitionId]').should('have.value', 'message_event_5');
   });
 });


### PR DESCRIPTION
Message Event IDs are unique on render. Initially, they were the same on render and if the user did not edit it `messageEvent Id` it would throw an error in Spark.

**Spark Video Demo**
https://drive.google.com/open?id=1MAW33gkScD3xrPbEYV2YHn5LVeFd6ZvP

Fixes #428 